### PR TITLE
Add a command for linking to a post

### DIFF
--- a/blogmore.el
+++ b/blogmore.el
@@ -2,7 +2,7 @@
 ;; Copyright 2026 by Dave Pearson <davep@davep.org>
 
 ;; Author: Dave Pearson <davep@davep.org>
-;; Version: 1.6
+;; Version: 1.7
 ;; Keywords: convenience
 ;; URL: https://github.com/davep/blogmore.el
 ;; Package-Requires: ((emacs "29.1"))


### PR DESCRIPTION
For the moment this follows the path scheme I use for my blog. At some point in the future it might be interesting to read the `blogmore.yaml` for the blog and use whatever's there; although that would then require parsing he frontmatter of the chosen post to pull out all the possible template variables for the path.