### PR TITLE
Improve `blogmore--frontmatter-bounds`

### DIFF
--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -20,7 +20,7 @@
      (let ((bounds (blogmore--frontmatter-bounds)))
        (should (consp bounds))
        (goto-char (car bounds))
-       (should (looking-at "\nTitle"))
+       (should (looking-at "Title"))
        (goto-char (cdr bounds))
        (should (looking-at "---"))))
    (with-temp-buffer

--- a/blogmore.el
+++ b/blogmore.el
@@ -261,7 +261,7 @@ frontmatter is found, return nil."
   (save-excursion
     (goto-char (point-min))
     (when (re-search-forward blogmore--frontmatter-marker-regexp nil t)
-      (let ((start (match-end 0)))
+      (let ((start (1+ (match-end 0))))
         (when (re-search-forward blogmore--frontmatter-marker-regexp nil t)
           (cons start (match-beginning 0)))))))
 


### PR DESCRIPTION
The start position was always on the EOL of the start marker, when the intention was that it would be the start of the first line of the frontmatter. While this never made a difference to how the rest of the code worked, it was a case of the docstring and the code not matching.

So here I fix the code, and update the test (which first made me realise the problem).