### PR TITLE
Tweaks to how `blogmore-slug` works

### DIFF
--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -6,6 +6,7 @@
   '(("" . "")
     ("Hello World!" . "hello-world")
     ("Emacs & Lisp" . "emacs-lisp")
+    ("That's a nice defun" . "thats-a-nice-defun")
     ("2026: A Blog Odyssey" . "2026-a-blog-odyssey")))
 
 (ert-deftest blogmore-slug-test ()

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -7,6 +7,7 @@
     ("Hello World!" . "hello-world")
     ("Emacs & Lisp" . "emacs-lisp")
     ("That's a nice defun" . "thats-a-nice-defun")
+    ("Café Ëmacs" . "cafe-emacs")
     ("2026: A Blog Odyssey" . "2026-a-blog-odyssey")))
 
 (ert-deftest blogmore-slug-test ()

--- a/blogmore.el
+++ b/blogmore.el
@@ -215,7 +215,7 @@ that can be parsed."
     downcase
     ;; "ASCIIfy" as many accented characters as possible.
     (ucs-normalize-NFKD-string)
-    (seq-filter (lambda (char) (or (<= char #x300) (>= char #x36F))))
+    (seq-filter (lambda (char) (or (< char #x300) (> char #x36F))))
     (concat)
     ;; Characters that are just flat out removed.
     (replace-regexp-in-string (rx (+ (any "'\""))) "")

--- a/blogmore.el
+++ b/blogmore.el
@@ -210,8 +210,15 @@ that can be parsed."
   "Generate a slug from the given TITLE."
   (thread-last
     title
+    ;; Make everything lowercase.
     downcase
+    ;; Characters that are just flat out removed.
+    (replace-regexp-in-string (rx (+ (any "'\""))) "")
+    ;; Replace any run of characters that aren't letters or numbers with a
+    ;; single dash.
     (replace-regexp-in-string (rx (+ (not (any "0-9a-z")))) "-")
+    ;; Remove any leading or trailing dashes that may have been introduced
+    ;; by the previous step.
     (replace-regexp-in-string (rx (or (seq bol "-") (seq "-" eol))) "")))
 
 (defun blogmore-get-frontmatter (property)

--- a/blogmore.el
+++ b/blogmore.el
@@ -40,6 +40,7 @@
 (require 'eieio-custom)
 (require 'parse-time)
 (require 'transient)
+(require 'ucs-normalize)
 
 
 (defclass blogmore-blog ()
@@ -212,6 +213,10 @@ that can be parsed."
     title
     ;; Make everything lowercase.
     downcase
+    ;; "ASCIIfy" as many accented characters as possible.
+    (ucs-normalize-NFKD-string)
+    (seq-filter (lambda (char) (or (<= char #x300) (>= char #x36F))))
+    (concat)
     ;; Characters that are just flat out removed.
     (replace-regexp-in-string (rx (+ (any "'\""))) "")
     ;; Replace any run of characters that aren't letters or numbers with a


### PR DESCRIPTION
Changes include:

- Some characters are simply removed now, for example it turns "let's" into "lets" rather than "let-s", etc.
- Accented characters are turned into the "ASCII version" where possible.