### PR TITLE
Make a straight toggle of bool frontmatter the default

### DIFF
--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -102,21 +102,37 @@
        (insert "No frontmatter here")
        (should-not (blogmore-remove-frontmatter "title")))))
 
-(ert-deftest blogmore-toggle-frontmatter-test ()
-   "Test toggling frontmatter properties."
+(ert-deftest blogmore-sticky-toggle-frontmatter-test ()
+   "Test toggling frontmatter properties in sticky mode."
    (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
      (with-temp-buffer
        (insert "---\ntitle: Test\nother: false\n---\n\nContent")
        (should (blogmore-toggle-frontmatter "test"))
        (should (equal (blogmore-get-frontmatter "test") "true"))
        (should (blogmore-toggle-frontmatter "test"))
-       (should-not (blogmore-get-frontmatter "test"))
+       (should (equal (blogmore-get-frontmatter "test") "false"))
        (should (equal (blogmore-get-frontmatter "other") "false"))
        (should (blogmore-toggle-frontmatter "other"))
        (should (equal (blogmore-get-frontmatter "other") "true")))
      (with-temp-buffer
        (insert "No frontmatter here")
        (should-not (blogmore-toggle-frontmatter "test")))))
+
+(ert-deftest blogmore-non-sticky-toggle-frontmatter-test ()
+   "Test toggling frontmatter properties in non-sticky mode."
+   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+     (with-temp-buffer
+       (insert "---\ntitle: Test\nother: false\n---\n\nContent")
+       (should (blogmore-toggle-frontmatter "test" t))
+       (should (equal (blogmore-get-frontmatter "test") "true"))
+       (should (blogmore-toggle-frontmatter "test" t))
+       (should-not (blogmore-get-frontmatter "test"))
+       (should (equal (blogmore-get-frontmatter "other") "false"))
+       (should (blogmore-toggle-frontmatter "other" t))
+       (should (equal (blogmore-get-frontmatter "other") "true")))
+     (with-temp-buffer
+       (insert "No frontmatter here")
+       (should-not (blogmore-toggle-frontmatter "test" t)))))
 
 (ert-deftest blogmore--blog-post-p-test ()
   "Test blogmore--blog-post-p returns correct values."

--- a/blogmore.el
+++ b/blogmore.el
@@ -264,12 +264,13 @@ t and the buffer is left unchanged."
         (kill-line)))
     t))
 
-(defun blogmore-toggle-frontmatter (property)
+(defun blogmore-toggle-frontmatter (property &optional remove-false)
   "Toggle the existence of boolean PROPERTY in the frontmatter.
 
 If the property doesn't exist, it is added with a value of true. If it
-does exist and if its value is true, it is removed. If it does exist and
-if its value is not true, its value is set to true.
+does exist and if its value is true and if REMOVE-FALSE is non-nil, it
+is removed, otherwise it is set to false. If it does exist and if its
+value is not true, its value is set to true.
 
 If a frontmatter section can't be found in the current buffer, the
 function returns nil, otherwise the property is toggled and the function
@@ -277,7 +278,9 @@ returns t."
   (if (and
        (blogmore--frontmatter-p property)
        (string-equal-ignore-case (blogmore-get-frontmatter property) "true"))
-      (blogmore-remove-frontmatter property)
+      (if remove-false
+          (blogmore-remove-frontmatter property)
+        (blogmore-set-frontmatter property "false"))
     (blogmore-set-frontmatter property "true")))
 
 
@@ -627,7 +630,7 @@ If an image is found the return value is a list of the form:
   "Toggle the draft status of the post."
   (interactive)
   (blogmore--within-post
-   (blogmore-toggle-frontmatter "draft")))
+   (blogmore-toggle-frontmatter "draft" t)))
 
 ;;;###autoload
 (defun blogmore-toggle-invite-comments ()


### PR DESCRIPTION
Update `blogmore-toggle-frontmatter` so that, by default, it *doesn't* remove a `false` front matter property. Some front matter is always `false` if omitted, some not. This allows for controlling that toggle correctly.