### PR TITLE
Improve frontmatter handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.elc
+.packages/
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,19 @@
-all:
-	emacs --batch -f batch-byte-compile blogmore.el
+EMACS_BATCH = HOME=/tmp/emacs-sandbox emacs -Q --batch -l dev-environment.el
 
+.PHONY: all
+all:
+	@echo "Byte-compiling blogmore.el..."
+	$(EMACS_BATCH) -f batch-byte-compile blogmore.el
+
+.PHONY: test
 test:
-	emacs --batch -l ert -l blogmore.el -l blogmore-tests.el -f ert-run-tests-batch-and-exit
+	@echo "Running test suite..."
+	$(EMACS_BATCH) -l blogmore.el -l blogmore-tests.el -f ert-run-tests-batch-and-exit
+
+.PHONY: clean
+clean:
+	@echo "Cleaning up build artifacts..."
+	rm -f *.elc
+	rm -rf .packages
 
 ### Makefile ends here

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,12 @@ test:
 
 .PHONY: clean
 clean:
-	@echo "Cleaning up build artifacts..."
+	@echo "Cleaning elc files..."
 	rm -f *.elc
+
+.PHONY: veryclean
+veryclean: clean
+	@echo "Cleaning dependencies..."
 	rm -rf .packages
 
 ### Makefile ends here

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-x1# blogmore.el
+# blogmore.el
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# blogmore.el
+x1# blogmore.el
 
 ## Introduction
 
@@ -66,35 +66,6 @@ configuration](https://github.com/davep/.emacs.d/blob/main/init.d/packages.d/per
 While, as I say above, I've tried to make it as configurable as possible,
 there are still some assumptions made and if your blog or posts don't match
 these then `blogmore.el` might not work so well for you.
-
-### Tags & Series
-
-It is assumed that your tags and series are always given as a
-comma-separated list like this:
-
-```yaml
-tags: Emacs, Lisp, Emacs Lisp, coding
-```
-
-rather than as an actual *list*:
-
-```yaml
-tags: [Emacs, Lisp, Emacs Lisp, coding]
-```
-
-or this kind of actual list:
-
-```yaml
-tags:
-  - Emacs
-  - Lisp
-  - Emacs Lisp
-  - coding
-```
-
-The frontmatter modification code in `blogmore.el` is pretty naive and
-*isn't* a proper frontmatter YAML parser. Perhaps at some point in the
-future, but not right now.
 
 ### Post dates
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ allow it to be used with a wide variety of different setups.
 
 `blogmore.el` is probably best installed with `use-package`, for example:
 
-
 ```elisp
 (use-package blogmore
   :ensure t
@@ -61,13 +60,7 @@ as of the time of writing:
 and you can always see the latest approach I'm using [in my Emacs
 configuration](https://github.com/davep/.emacs.d/blob/main/init.d/packages.d/personal/blogmore.el).
 
-## Assumptions
-
-While, as I say above, I've tried to make it as configurable as possible,
-there are still some assumptions made and if your blog or posts don't match
-these then `blogmore.el` might not work so well for you.
-
-### Post dates
+## Assumption about post date format
 
 It is assumed that your post dates will be something akin to ISO8601 format.
 So ideally something like:

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -38,21 +38,6 @@
      (insert "No frontmatter here")
      (should-not (blogmore--frontmatter-bounds))))
 
-(ert-deftest blogmore--locate-frontmatter-test ()
-   "Test locating frontmatter properties."
-   (with-temp-buffer
-     (insert "---\ntitle: Test Title\ndate: 2026-04-02\n---\n\nContent")
-     (let ((result (blogmore--locate-frontmatter "title")))
-       (should (blogmore--frontmatter-property-location-p result))
-       (should (equal
-                (string-trim
-                 (buffer-substring
-                  (blogmore--frontmatter-property-location-start result)
-                  (blogmore--frontmatter-property-location-end result)))
-                (blogmore--frontmatter-property-location-value result)))
-       (should (equal (blogmore--frontmatter-property-location-value result) "Test Title")))
-     (should-not (blogmore--locate-frontmatter "category"))))
-
 (ert-deftest blogmore--frontmatter-p-test ()
    "Test detection of frontmatter presence."
    (with-temp-buffer
@@ -108,12 +93,12 @@
      (with-temp-buffer
        (insert "---\ntitle: Test\nother: false\n---\n\nContent")
        (should (blogmore-toggle-frontmatter "test"))
-       (should (equal (blogmore-get-frontmatter "test") "true"))
+       (should (equal (blogmore-get-frontmatter "test") t))
        (should (blogmore-toggle-frontmatter "test"))
-       (should (equal (blogmore-get-frontmatter "test") "false"))
-       (should (equal (blogmore-get-frontmatter "other") "false"))
+       (should (equal (blogmore-get-frontmatter "test") nil))
+       (should (equal (blogmore-get-frontmatter "other") nil))
        (should (blogmore-toggle-frontmatter "other"))
-       (should (equal (blogmore-get-frontmatter "other") "true")))
+       (should (equal (blogmore-get-frontmatter "other") t)))
      (with-temp-buffer
        (insert "No frontmatter here")
        (should-not (blogmore-toggle-frontmatter "test")))))
@@ -124,12 +109,12 @@
      (with-temp-buffer
        (insert "---\ntitle: Test\nother: false\n---\n\nContent")
        (should (blogmore-toggle-frontmatter "test" t))
-       (should (equal (blogmore-get-frontmatter "test") "true"))
+       (should (blogmore-get-frontmatter "test"))
        (should (blogmore-toggle-frontmatter "test" t))
        (should-not (blogmore-get-frontmatter "test"))
-       (should (equal (blogmore-get-frontmatter "other") "false"))
+       (should-not (blogmore-get-frontmatter "other"))
        (should (blogmore-toggle-frontmatter "other" t))
-       (should (equal (blogmore-get-frontmatter "other") "true")))
+       (should (equal (blogmore-get-frontmatter "other") t)))
      (with-temp-buffer
        (insert "No frontmatter here")
        (should-not (blogmore-toggle-frontmatter "test" t)))))

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -238,13 +238,13 @@
       (let ((inhibit-message t))
         (should-not (blogmore-get-frontmatter "tags"))
         (blogmore-add-tag "Emacs")
-        (should (equal (blogmore-get-frontmatter "tags") "Emacs"))
+        (should (equal (blogmore--post-tags) '("Emacs")))
         (blogmore-add-tag "Lisp")
-        (should (equal (blogmore-get-frontmatter "tags") "Emacs, Lisp"))
+        (should (equal (blogmore--post-tags) '("Emacs" "Lisp")))
         (blogmore-add-tag "Emacs")
-        (should (equal (blogmore-get-frontmatter "tags") "Emacs, Lisp"))
+        (should (equal (blogmore--post-tags) '("Emacs" "Lisp")))
         (blogmore-add-tag "A")
-        (should (equal (blogmore-get-frontmatter "tags") "A, Emacs, Lisp"))))))
+        (should (equal (blogmore--post-tags) '("A" "Emacs" "Lisp")))))))
 
 (ert-deftest blogmore-remove-tag-test ()
   "Test that blogmore-remove-tag removes a tag from the current post."
@@ -252,12 +252,12 @@
     (with-temp-buffer
       (insert "---\ntitle: Test\ntags: A, Emacs, Lisp\n---\n\nContent")
       (let ((inhibit-message t))
-        (should (equal (blogmore-get-frontmatter "tags") "A, Emacs, Lisp"))
+        (should (equal (blogmore--post-tags) '("A" "Emacs" "Lisp")))
         (blogmore-remove-tag "Emacs")
-        (should (equal (blogmore-get-frontmatter "tags") "A, Lisp"))
+        (should (equal (blogmore--post-tags) '("A" "Lisp")))
         (blogmore-remove-tag "A")
-        (should (equal (blogmore-get-frontmatter "tags") "Lisp"))
+        (should (equal (blogmore--post-tags) '("Lisp")))
         (blogmore-remove-tag "Lisp")
-        (should (equal (blogmore-get-frontmatter "tags") ""))))))
+        (should (equal (blogmore--post-tags) nil))))))
 
 ;;; blogmore-tests.el ends here

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -25,99 +25,99 @@
   (should (equal (blogmore--cycle-image-type "foo") "jpeg")))
 
 (ert-deftest blogmore--frontmatter-bounds-test ()
-   "Test detection of frontmatter bounds."
-   (with-temp-buffer
-     (insert "---\ntitle: Test\ndate: 2026-04-02\n---\nContent")
-     (let ((bounds (blogmore--frontmatter-bounds)))
-       (should (consp bounds))
-       (goto-char (car bounds))
-       (should (looking-at "Title"))
-       (goto-char (cdr bounds))
-       (should (looking-at "---"))))
-   (with-temp-buffer
-     (insert "No frontmatter here")
-     (should-not (blogmore--frontmatter-bounds))))
+  "Test detection of frontmatter bounds."
+  (with-temp-buffer
+    (insert "---\ntitle: Test\ndate: 2026-04-02\n---\nContent")
+    (let ((bounds (blogmore--frontmatter-bounds)))
+      (should (consp bounds))
+      (goto-char (car bounds))
+      (should (looking-at "Title"))
+      (goto-char (cdr bounds))
+      (should (looking-at "---"))))
+  (with-temp-buffer
+    (insert "No frontmatter here")
+    (should-not (blogmore--frontmatter-bounds))))
 
 (ert-deftest blogmore--frontmatter-p-test ()
-   "Test detection of frontmatter presence."
-   (with-temp-buffer
-     (insert "---\ntitle: Test\n---\n\nContent")
-     (should (blogmore--frontmatter-p "title"))
-     (should-not (blogmore--frontmatter-p "category")))
-   (with-temp-buffer
-     (insert "No frontmatter here")
-     (should-not (blogmore--frontmatter-p "title"))))
+  "Test detection of frontmatter presence."
+  (with-temp-buffer
+    (insert "---\ntitle: Test\n---\n\nContent")
+    (should (blogmore--frontmatter-p "title"))
+    (should-not (blogmore--frontmatter-p "category")))
+  (with-temp-buffer
+    (insert "No frontmatter here")
+    (should-not (blogmore--frontmatter-p "title"))))
 
 (ert-deftest blogmore-get-frontmatter-test ()
-   "Test retrieval of frontmatter values."
-   (with-temp-buffer
-     (insert "---\ntitle: Test Title\ndate: 2026-04-02\n---\n\nContent")
-     (should (equal (blogmore-get-frontmatter "title") "Test Title"))
-     (should-not (blogmore-get-frontmatter "category")))
-   (with-temp-buffer
-     (insert "No frontmatter here")
-     (should-not (blogmore-get-frontmatter "title"))))
+  "Test retrieval of frontmatter values."
+  (with-temp-buffer
+    (insert "---\ntitle: Test Title\ndate: 2026-04-02\n---\n\nContent")
+    (should (equal (blogmore-get-frontmatter "title") "Test Title"))
+    (should-not (blogmore-get-frontmatter "category")))
+  (with-temp-buffer
+    (insert "No frontmatter here")
+    (should-not (blogmore-get-frontmatter "title"))))
 
 (ert-deftest blogmore-set-frontmatter-test ()
-   "Test setting frontmatter properties."
-   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
-     (with-temp-buffer
-       (insert "---\n---\n")
-       (should (blogmore-set-frontmatter "title" "New Title"))
-       (should (equal (blogmore-get-frontmatter "title") "New Title"))
-       (should (blogmore-set-frontmatter "title" "Newer Title"))
-       (should (equal (blogmore-get-frontmatter "title") "Newer Title"))
-       (should (blogmore-set-frontmatter "category" "Tech"))
-       (should (equal (blogmore-get-frontmatter "category") "Tech"))
-       (should (blogmore-set-frontmatter "empty" ""))
-       (should (equal (blogmore-get-frontmatter "empty") "")))
-     (with-temp-buffer
-       (insert "No frontmatter here")
-       (should-not (blogmore-set-frontmatter "title" "New Title")))))
+  "Test setting frontmatter properties."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\n---\n")
+      (should (blogmore-set-frontmatter "title" "New Title"))
+      (should (equal (blogmore-get-frontmatter "title") "New Title"))
+      (should (blogmore-set-frontmatter "title" "Newer Title"))
+      (should (equal (blogmore-get-frontmatter "title") "Newer Title"))
+      (should (blogmore-set-frontmatter "category" "Tech"))
+      (should (equal (blogmore-get-frontmatter "category") "Tech"))
+      (should (blogmore-set-frontmatter "empty" ""))
+      (should (equal (blogmore-get-frontmatter "empty") "")))
+    (with-temp-buffer
+      (insert "No frontmatter here")
+      (should-not (blogmore-set-frontmatter "title" "New Title")))))
 
 (ert-deftest blogmore-remove-frontmatter-test ()
-   "Test removal of frontmatter properties."
-   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
-     (with-temp-buffer
-       (insert "---\ntitle: Test\ncategory: Tech\n---\n\nContent")
-       (should (blogmore-remove-frontmatter "title"))
-       (should-not (blogmore-get-frontmatter "title"))
-       (should (blogmore-get-frontmatter "category")))
-     (with-temp-buffer
-       (insert "No frontmatter here")
-       (should-not (blogmore-remove-frontmatter "title")))))
+  "Test removal of frontmatter properties."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\ntitle: Test\ncategory: Tech\n---\n\nContent")
+      (should (blogmore-remove-frontmatter "title"))
+      (should-not (blogmore-get-frontmatter "title"))
+      (should (blogmore-get-frontmatter "category")))
+    (with-temp-buffer
+      (insert "No frontmatter here")
+      (should-not (blogmore-remove-frontmatter "title")))))
 
 (ert-deftest blogmore-sticky-toggle-frontmatter-test ()
-   "Test toggling frontmatter properties in sticky mode."
-   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
-     (with-temp-buffer
-       (insert "---\ntitle: Test\nother: false\n---\n\nContent")
-       (should (blogmore-toggle-frontmatter "test"))
-       (should (equal (blogmore-get-frontmatter "test") t))
-       (should (blogmore-toggle-frontmatter "test"))
-       (should (equal (blogmore-get-frontmatter "test") nil))
-       (should (equal (blogmore-get-frontmatter "other") nil))
-       (should (blogmore-toggle-frontmatter "other"))
-       (should (equal (blogmore-get-frontmatter "other") t)))
-     (with-temp-buffer
-       (insert "No frontmatter here")
-       (should-not (blogmore-toggle-frontmatter "test")))))
+  "Test toggling frontmatter properties in sticky mode."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\ntitle: Test\nother: false\n---\n\nContent")
+      (should (blogmore-toggle-frontmatter "test"))
+      (should (equal (blogmore-get-frontmatter "test") t))
+      (should (blogmore-toggle-frontmatter "test"))
+      (should (equal (blogmore-get-frontmatter "test") nil))
+      (should (equal (blogmore-get-frontmatter "other") nil))
+      (should (blogmore-toggle-frontmatter "other"))
+      (should (equal (blogmore-get-frontmatter "other") t)))
+    (with-temp-buffer
+      (insert "No frontmatter here")
+      (should-not (blogmore-toggle-frontmatter "test")))))
 
 (ert-deftest blogmore-non-sticky-toggle-frontmatter-test ()
-   "Test toggling frontmatter properties in non-sticky mode."
-   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
-     (with-temp-buffer
-       (insert "---\ntitle: Test\nother: false\n---\n\nContent")
-       (should (blogmore-toggle-frontmatter "test" t))
-       (should (blogmore-get-frontmatter "test"))
-       (should (blogmore-toggle-frontmatter "test" t))
-       (should-not (blogmore-get-frontmatter "test"))
-       (should-not (blogmore-get-frontmatter "other"))
-       (should (blogmore-toggle-frontmatter "other" t))
-       (should (equal (blogmore-get-frontmatter "other") t)))
-     (with-temp-buffer
-       (insert "No frontmatter here")
-       (should-not (blogmore-toggle-frontmatter "test" t)))))
+  "Test toggling frontmatter properties in non-sticky mode."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\ntitle: Test\nother: false\n---\n\nContent")
+      (should (blogmore-toggle-frontmatter "test" t))
+      (should (blogmore-get-frontmatter "test"))
+      (should (blogmore-toggle-frontmatter "test" t))
+      (should-not (blogmore-get-frontmatter "test"))
+      (should-not (blogmore-get-frontmatter "other"))
+      (should (blogmore-toggle-frontmatter "other" t))
+      (should (equal (blogmore-get-frontmatter "other") t)))
+    (with-temp-buffer
+      (insert "No frontmatter here")
+      (should-not (blogmore-toggle-frontmatter "test" t)))))
 
 (ert-deftest blogmore--blog-post-p-test ()
   "Test blogmore--blog-post-p returns correct values."
@@ -138,14 +138,14 @@
       (should-not (blogmore--blog-post-p)))))
 
 (ert-deftest blogmore--insert-link-test ()
-   "Test blogmore--insert-link inserts a Markdown link and point on the closing ]."
-   (with-temp-buffer
-     (blogmore--insert-link "https://example.com")
-     (should (equal (buffer-string) "[](https://example.com)"))
-     (should (looking-at "]"))))
+  "Test blogmore--insert-link inserts a Markdown link and point on the closing ]."
+  (with-temp-buffer
+    (blogmore--insert-link "https://example.com")
+    (should (equal (buffer-string) "[](https://example.com)"))
+    (should (looking-at "]"))))
 
 (ert-deftest blogmore--within-post-test ()
-   "Test blogmore--within-post macro behavior."
+  "Test blogmore--within-post macro behavior."
   (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
     (with-temp-buffer
       (insert "---\ntitle: Test\n---\n\nContent")

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -179,21 +179,6 @@
                          (cdr case))
                  (blogmore--file-from-title (car case))))))))
 
-(ert-deftest blogmore--current-categories-test ()
-  "Test extraction of categories from post content."
-  (cl-letf (((symbol-function 'blogmore--get-all)
-             (lambda (_ &optional _)
-               '("Z" "Emacs" "Lisp" "Life" "A"))))
-    (should (equal (blogmore--current-categories) '("A" "Emacs" "Life" "Lisp" "Z")))))
-
-(ert-deftest blogmore--current-tags-test ()
-  "Test extraction of tags from post content."
-  (cl-letf (((symbol-function 'blogmore--get-all)
-             (lambda (_ &optional _)
-               '("Emacs" "Lisp" "Emacs" "Org" "Lisp" "Emacs" "Z" "A"))))
-    (should (equal (sort (blogmore--current-tags) #'string-lessp)
-                   '("A" "Emacs" "Lisp" "Org" "Z")))))
-
 (ert-deftest blogmore--chosen-blog-sans-error-test ()
   "Test that blogmore--chosen-blog-sans-error smartly defaults."
   ;; With no blog selected by the user.

--- a/blogmore-tests.el
+++ b/blogmore-tests.el
@@ -260,4 +260,28 @@
         (blogmore-remove-tag "Lisp")
         (should (equal (blogmore--post-tags) nil))))))
 
+(ert-deftest blogmore-add-series-test ()
+  "Test that blogmore-add-series adds a series to the current post."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\ntitle: Test\n---\n\nContent")
+      (let ((inhibit-message t))
+        (should-not (blogmore--post-series))
+        (blogmore-add-series "Emacs Tips")
+        (should (equal (blogmore--post-series) '("Emacs Tips")))
+        (blogmore-add-series "Lisp Tricks")
+        (should (equal (blogmore--post-series) '("Emacs Tips" "Lisp Tricks")))))))
+
+(ert-deftest blogmore-remove-series-test ()
+  "Test that blogmore-remove-series removes a series from the current post."
+  (let ((blogmore--current-blog (blogmore-blog :posts-directory "/tmp/")))
+    (with-temp-buffer
+      (insert "---\ntitle: Test\nseries: Emacs Tips, Lisp Tricks\n---\n\nContent")
+      (let ((inhibit-message t))
+        (should (equal (blogmore--post-series) '("Emacs Tips" "Lisp Tricks")))
+        (blogmore-remove-series "Emacs Tips")
+        (should (equal (blogmore--post-series) '("Lisp Tricks")))
+        (blogmore-remove-series "Lisp Tricks")
+        (should (equal (blogmore--post-series) nil))))))
+
 ;;; blogmore-tests.el ends here

--- a/blogmore.el
+++ b/blogmore.el
@@ -700,7 +700,9 @@ If an image is found the return value is a list of the form:
    (list (when-let (series (blogmore--post-series))
            (completing-read "Series to remove: " series nil t))))
   (when series
-    (blogmore-set-frontmatter "series" (remove series (blogmore--post-series)))
+    (if-let ((remaining-series (remove series (blogmore--post-series))))
+        (blogmore-set-frontmatter "series" remaining-series)
+      (blogmore-remove-frontmatter "series"))
     (message "Removed series '%s'" series)))
 
 (defun blogmore--post-tags ()
@@ -732,7 +734,9 @@ If an image is found the return value is a list of the form:
    (list (when-let (tags (blogmore--post-tags))
            (completing-read "Tag to remove: " tags nil t))))
   (when tag
-    (blogmore-set-frontmatter "tags" (remove tag (blogmore--post-tags)))
+    (if-let ((remaining-tags (remove tag (blogmore--post-tags))))
+        (blogmore-set-frontmatter "tags" remaining-tags)
+      (blogmore-remove-frontmatter "tags"))
     (message "Removed tag '%s'" tag)
     (when transient-current-prefix
       (call-interactively #'blogmore-remove-tag))))

--- a/blogmore.el
+++ b/blogmore.el
@@ -473,18 +473,25 @@ to select a blog to work on first."
 
 (defun blogmore--list-of (property)
   "Get the PROPERTY list from BlogMore."
-  (if (executable-find blogmore-command)
-      (mapcar
-       #'cadr
-       (json-parse-string
-        (shell-command-to-string
-         (format "%s dump %s \"%s\" 2> %s"
-                 blogmore-command
-                 property
-                 (expand-file-name (blogmore--posts-directory))
-                 (shell-quote-argument (null-device))))
-        :array-type 'list))
-    (user-error "The 'blogmore' command-line tool is required for this operation; https://blogmore.davep.dev/")))
+  (unless (executable-find blogmore-command)
+    (user-error
+     "The 'blogmore' command-line tool is required for this operation; https://blogmore.davep.dev/"))
+  (let* ((command (format "%s dump %s \"%s\" 2> %s"
+                          blogmore-command
+                          property
+                          (expand-file-name (blogmore--posts-directory))
+                          (shell-quote-argument (null-device))))
+         (data (shell-command-to-string command)))
+    (when (string-empty-p data)
+      (user-error "%s did not return any data for %s" command property))
+    (mapcar #'cadr
+            (condition-case parse-error
+                (json-parse-string data :array-type 'list)
+              (error
+               (user-error
+                "Error parsing output from %s -- %s"
+                command
+                (error-message-string parse-error)))))))
 
 (defun blogmore--current-categories ()
   "Get a list of categories from existing posts."

--- a/blogmore.el
+++ b/blogmore.el
@@ -295,9 +295,9 @@ returns t."
 
 If BlogMore is installed and in your path the default setting should be
 fine. However, if you have multiple versions of BlogMore installed, or
-possibly have virtual environments appearing on your `exec-path', this
-might cause problems. If so you can set this to point to a specific
-instance of BlogMore."
+possibly have virtual environments appearing in the variable
+`exec-path', this might cause problems. If so you can set this to point
+to a specific instance of BlogMore."
   :type '(file :must-match t)
   :group 'blogmore)
 

--- a/blogmore.el
+++ b/blogmore.el
@@ -493,17 +493,32 @@ to select a blog to work on first."
                 command
                 (error-message-string parse-error)))))))
 
+(defvar blogmore--current-categories-cache nil
+  "Cache for the list of categories from existing posts.")
+
 (defun blogmore--current-categories ()
   "Get a list of categories from existing posts."
-  (blogmore--list-of "categories"))
+  (or
+   blogmore--current-categories-cache
+   (setq blogmore--current-categories-cache (blogmore--list-of "categories"))))
+
+(defvar blogmore--current-tags-cache nil
+  "Cache for the list of tags from existing posts.")
 
 (defun blogmore--current-tags ()
   "Get a list of tags from existing posts."
-  (blogmore--list-of "tags"))
+  (or
+   blogmore--current-tags-cache
+   (setq blogmore--current-tags-cache (blogmore--list-of "tags"))))
+
+(defvar blogmore--current-series-cache nil
+  "Cache for the list of series from existing posts.")
 
 (defun blogmore--current-series ()
   "Get a list of series from existing posts."
-  (blogmore--list-of "series"))
+  (or
+   blogmore--current-series-cache
+   (setq blogmore--current-series-cache (blogmore--list-of "series"))))
 
 (defun blogmore--post-picker ()
   "Pick a post from the list of existing posts."
@@ -578,6 +593,14 @@ If an image is found the return value is a list of the form:
 ;; Commands:
 
 ;;;###autoload
+(defun blogmore-clear-caches ()
+  "Clear the caches for categories, tags, and series, etc."
+  (interactive)
+  (setq blogmore--current-categories-cache nil
+        blogmore--current-tags-cache nil
+        blogmore--current-series-cache nil))
+
+;;;###autoload
 (defun blogmore-work-on (blog)
   "Set the current blog to BLOG."
   (interactive (list (completing-read "Blog: " (mapcar #'blogmore-blog-title blogmore-blogs) nil t)))
@@ -586,6 +609,7 @@ If an image is found the return value is a list of the form:
          (lambda (candidate)
            (string= (blogmore-blog-title candidate) blog))
          blogmore-blogs))
+  (blogmore-clear-caches)
   (message "Now working on %s" blog)
   (when transient-current-prefix
     (call-interactively #'blogmore)))
@@ -837,7 +861,8 @@ If an image is found the return value is a list of the form:
     ("C t" "Toggle invite comments" blogmore-toggle-invite-comments :inapt-if-not blogmore--blog-post-p)
     ("C a" "Comments to address" blogmore-invite-comments-to :inapt-if-not blogmore--blog-post-p)
     ("o s" "Toggle show ToC" blogmore-toggle-show-toc :inapt-if-not blogmore--blog-post-p)
-    ("o i" "Toggle show ToC inline" blogmore-toggle-show-toc-inline :inapt-if-not blogmore--blog-post-p)]])
+    ("o i" "Toggle show ToC inline" blogmore-toggle-show-toc-inline :inapt-if-not blogmore--blog-post-p)
+    ("x c" "Clear caches" blogmore-clear-caches)]])
 
 (provide 'blogmore)
 

--- a/blogmore.el
+++ b/blogmore.el
@@ -803,10 +803,11 @@ If an image is found the return value is a list of the form:
   "Copy the category and tags from POST to the current post."
   (interactive (blogmore--post-picker))
   (blogmore--within-post
-   (when-let ((category (blogmore-with-post post (blogmore-get-frontmatter "category"))))
-     (blogmore-set-category category)))
-   (when-let ((tags (blogmore-with-post post (blogmore-get-frontmatter "tags"))))
-     (blogmore-set-frontmatter "tags" tags)))
+   (let ((frontmatter (blogmore-with-post post (blogmore--frontmatter))))
+     (when-let ((category (blogmore-get-frontmatter "category" frontmatter)))
+       (blogmore-set-category category))
+     (when-let ((tags (blogmore-get-frontmatter "tags" frontmatter)))
+       (blogmore-set-frontmatter "tags" tags)))))
 
 ;;;###autoload
 (transient-define-prefix blogmore ()

--- a/blogmore.el
+++ b/blogmore.el
@@ -144,11 +144,6 @@ frontmatter is found, return nil."
         (when (re-search-forward blogmore--frontmatter-marker-regexp nil t)
           (cons start (match-beginning 0)))))))
 
-(defun blogmore--frontmatter-text ()
-  "Return the text of the frontmatter, or nil if no frontmatter is found."
-  (when-let ((bounds (blogmore--frontmatter-bounds)))
-    (buffer-substring-no-properties (car bounds) (cdr bounds))))
-
 (defun blogmore--frontmatter ()
   "Return the frontmatter as a YAML object, or nil if no frontmatter is found."
   (when-let ((bounds (blogmore--frontmatter-bounds)))

--- a/blogmore.el
+++ b/blogmore.el
@@ -222,9 +222,12 @@ that can be parsed."
     ;; by the previous step.
     (replace-regexp-in-string (rx (or (seq bol "-") (seq "-" eol))) "")))
 
-(defun blogmore-get-frontmatter (property)
-  "Get the value of PROPERTY from the frontmatter, or nil if it doesn't exist."
-  (cdr (assoc property (blogmore--frontmatter))))
+(defun blogmore-get-frontmatter (property &optional frontmatter)
+  "Get the value of PROPERTY from the frontmatter, or nil if it doesn't exist.
+
+If FRONTMATTER is provided, it is used instead of parsing the
+frontmatter from the buffer."
+  (cdr (assoc property (or frontmatter (blogmore--frontmatter)))))
 
 (defun blogmore-set-frontmatter (property value)
   "Set the value of PROPERTY in the frontmatter to VALUE.

--- a/blogmore.el
+++ b/blogmore.el
@@ -184,7 +184,7 @@ frontmatter is found, return nil."
   (declare (indent 1))
   `(with-temp-buffer
      (insert-file-contents ,post-file)
-      ,@body))
+     ,@body))
 
 (defun blogmore-clean-time-string (time-string)
   "Clean TIME-STRING to the format YYYY-MM-DDTHH:MM:SS+NNNN.
@@ -393,6 +393,7 @@ a new blog post."
 
 (defmacro blogmore--within-post (&rest body)
   "Execute BODY within a blog post, or signal an error if we're not in a blog post."
+  (declare (indent 0))
   `(if (blogmore--blog-post-p)
        (progn ,@body)
      (user-error "This doesn't look like a blog post")))
@@ -536,10 +537,10 @@ to select a blog to work on first."
 (defun blogmore--with (prompt existing-values)
   "Prompt the user with PROMPT and offer EXISTING-VALUES as completions."
   (blogmore--within-post
-   (list
-    (completing-read
-     (format "%s from %s: " prompt (blogmore--blog-title))
-     existing-values))))
+    (list
+     (completing-read
+      (format "%s from %s: " prompt (blogmore--blog-title))
+      existing-values))))
 
 (defsubst blogmore--image-extension (image)
   "Get the extension of IMAGE, or nil if it doesn't have one."
@@ -638,28 +639,28 @@ If an image is found the return value is a list of the form:
   "Toggle the draft status of the post."
   (interactive)
   (blogmore--within-post
-   (blogmore-toggle-frontmatter "draft" t)))
+    (blogmore-toggle-frontmatter "draft" t)))
 
 ;;;###autoload
 (defun blogmore-toggle-invite-comments ()
   "Toggle the invite-comments status of the post."
   (interactive)
   (blogmore--within-post
-   (blogmore-toggle-frontmatter "invite_comments")))
+    (blogmore-toggle-frontmatter "invite_comments")))
 
 ;;;###autoload
 (defun blogmore-toggle-show-toc ()
   "Toggle the show-toc status of the post."
   (interactive)
   (blogmore--within-post
-   (blogmore-toggle-frontmatter "show_toc")))
+    (blogmore-toggle-frontmatter "show_toc")))
 
 ;;;###autoload
 (defun blogmore-toggle-show-toc-inline ()
   "Toggle the show-toc-inline status of the post."
   (interactive)
   (blogmore--within-post
-   (blogmore-toggle-frontmatter "show_toc_inline")))
+    (blogmore-toggle-frontmatter "show_toc_inline")))
 
 ;;;###autoload
 (defun blogmore-invite-comments-to (address)
@@ -816,13 +817,13 @@ If an image is found the return value is a list of the form:
   "Copy the category and tags from POST to the current post."
   (interactive (blogmore--post-picker))
   (blogmore--within-post
-   (let ((frontmatter (blogmore-with-post post (blogmore--frontmatter))))
-     (when-let ((category (blogmore-get-frontmatter "category" frontmatter)))
-       (blogmore-set-category category))
-     (when-let ((tags (blogmore-get-frontmatter "tags" frontmatter)))
-       (blogmore-set-frontmatter "tags" tags))
-     (when-let ((series (blogmore-get-frontmatter "series" frontmatter)))
-       (blogmore-set-frontmatter "series" series)))))
+    (let ((frontmatter (blogmore-with-post post (blogmore--frontmatter))))
+      (when-let ((category (blogmore-get-frontmatter "category" frontmatter)))
+        (blogmore-set-category category))
+      (when-let ((tags (blogmore-get-frontmatter "tags" frontmatter)))
+        (blogmore-set-frontmatter "tags" tags))
+      (when-let ((series (blogmore-get-frontmatter "series" frontmatter)))
+        (blogmore-set-frontmatter "series" series)))))
 
 ;;;###autoload
 (transient-define-prefix blogmore ()

--- a/blogmore.el
+++ b/blogmore.el
@@ -5,7 +5,7 @@
 ;; Version: 4.7.0
 ;; Keywords: convenience
 ;; URL: https://github.com/davep/blogmore.el
-;; Package-Requires: ((emacs "29.1"))
+;; Package-Requires: ((emacs "29.1") (yaml "1.2.4"))
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -41,6 +41,7 @@
 (require 'subr-x)
 (require 'transient)
 (require 'ucs-normalize)
+(require 'yaml)
 
 
 (defclass blogmore-blog ()
@@ -143,42 +144,37 @@ frontmatter is found, return nil."
         (when (re-search-forward blogmore--frontmatter-marker-regexp nil t)
           (cons start (match-beginning 0)))))))
 
-(cl-defstruct blogmore--frontmatter-property-location
-  "A struct representing the location of a property in the frontmatter."
-  (start nil :documentation "The position of the start of the property's value.")
-  (end nil :documentation "The position of the end of the property's value.")
-  (value nil :documentation "The current value of the property."))
-
-(defun blogmore--locate-frontmatter (property)
-  "Locate the line for PROPERTY in the frontmatter.
-
-If the property is found, return an instance of
-`blogmore--frontmatter-property-location' with the start, end, and value
-of the property. If the property is not found, return nil.
-
-If the property is found `point' is left at the beginning of the value.
-If the property is not found, `point' is left at the end of the
-frontmatter.
-
-If there are no frontmatter markers, return nil and leave `point`
-unchanged."
+(defun blogmore--frontmatter-text ()
+  "Return the text of the frontmatter, or nil if no frontmatter is found."
   (when-let ((bounds (blogmore--frontmatter-bounds)))
-    (with-restriction (car bounds) (cdr bounds)
-      (goto-char (point-min))
-      (if (re-search-forward (rx bol (literal property) ":") nil t)
-          (make-blogmore--frontmatter-property-location
-           :start (point)
-           :end (line-end-position)
-           :value (string-trim
-                   (buffer-substring-no-properties
-                    (point)
-                    (line-end-position))))
-        (ignore (goto-char (point-max)))))))
+    (buffer-substring-no-properties (car bounds) (cdr bounds))))
+
+(defun blogmore--frontmatter ()
+  "Return the frontmatter as a YAML object, or nil if no frontmatter is found."
+  (when-let ((bounds (blogmore--frontmatter-bounds)))
+    (yaml-parse-string
+     (buffer-substring-no-properties (car bounds) (cdr bounds))
+     :false-object nil
+     :null-object nil
+     :object-key-type 'string
+     :object-type 'alist
+     :sequence-type 'list)))
+
+(gv-define-setter blogmore--frontmatter (new-frontmatter)
+  "Set the frontmatter of the current buffer to NEW-FRONTMATTER."
+  (let ((frontmatter (gensym "new-frontmatter-")))
+    `(let ((bounds (blogmore--frontmatter-bounds))
+           (,frontmatter ,new-frontmatter))
+       (if bounds
+           (replace-region-contents
+            (car bounds) (cdr bounds)
+            (lambda ()
+              (concat (yaml-encode ,frontmatter) "\n")))
+         (error "No frontmatter bounds found to update")))))
 
 (defun blogmore--frontmatter-p (property)
   "Return non-nil if PROPERTY exists in the frontmatter."
-  (save-excursion
-    (blogmore--locate-frontmatter property)))
+  (assoc property (blogmore--frontmatter)))
 
 
 ;; Public utility macros and functions.
@@ -228,9 +224,7 @@ that can be parsed."
 
 (defun blogmore-get-frontmatter (property)
   "Get the value of PROPERTY from the frontmatter, or nil if it doesn't exist."
-  (save-excursion
-    (when-let ((location (blogmore--locate-frontmatter property)))
-      (blogmore--frontmatter-property-location-value location))))
+  (cdr (assoc property (blogmore--frontmatter))))
 
 (defun blogmore-set-frontmatter (property value)
   "Set the value of PROPERTY in the frontmatter to VALUE.
@@ -239,15 +233,11 @@ If a frontmatter section can't be found in the current buffer, the
 function returns nil, otherwise PROPERTY is set to VALUE and the
 function returns t."
   (when (blogmore--frontmatter-bounds)
-    (save-excursion
-      (if-let ((location (blogmore--locate-frontmatter property)))
-          (progn
-            (goto-char (blogmore--frontmatter-property-location-start location))
-            (kill-region (point) (line-end-position))
-            (insert (format " %s" value)))
-        (beginning-of-line)
-        (insert (format "%s: %s\n" property value)))
-      t)))
+    (let ((frontmatter (blogmore--frontmatter)))
+      (if-let ((existing (assoc-string property frontmatter)))
+          (setf (cdr existing) value)
+        (setf frontmatter (append frontmatter (list (cons property value)))))
+      (setf (blogmore--frontmatter) frontmatter))))
 
 (defun blogmore-remove-frontmatter (property)
   "Remove PROPERTY from the frontmatter.
@@ -257,12 +247,8 @@ function returns nil, otherwise PROPERTY is removed and the function
 returns t. In the event that PROPERTY is not found, the function returns
 t and the buffer is left unchanged."
   (when (blogmore--frontmatter-bounds)
-    (save-excursion
-      (when-let ((location (blogmore--locate-frontmatter property)))
-        (goto-char (blogmore--frontmatter-property-location-start location))
-        (delete-region (line-beginning-position) (line-end-position))
-        (kill-line)))
-    t))
+    (let ((frontmatter (blogmore--frontmatter)))
+      (setf (blogmore--frontmatter) (assoc-delete-all property frontmatter)))))
 
 (defun blogmore-toggle-frontmatter (property &optional remove-false)
   "Toggle the existence of boolean PROPERTY in the frontmatter.
@@ -277,7 +263,7 @@ function returns nil, otherwise the property is toggled and the function
 returns t."
   (if (and
        (blogmore--frontmatter-p property)
-       (string-equal-ignore-case (blogmore-get-frontmatter property) "true"))
+       (blogmore-get-frontmatter property))
       (if remove-false
           (blogmore-remove-frontmatter property)
         (blogmore-set-frontmatter property "false"))

--- a/blogmore.el
+++ b/blogmore.el
@@ -661,18 +661,42 @@ If an image is found the return value is a list of the form:
   (interactive (blogmore--with "Category" (blogmore--current-categories)))
   (blogmore-set-frontmatter "category" category))
 
+(defun blogmore--post-series ()
+  "Get the series for the current post as a list."
+  (when-let ((series (blogmore-get-frontmatter "series")))
+    (if (stringp series)
+        (string-split series "," t " ")
+      series)))
+
+;;;###autoload
+(defun blogmore-add-series (series)
+  "Add SERIES to the post's series."
+  (interactive (blogmore--with "Series" (blogmore--current-series)))
+  (blogmore-set-frontmatter
+   "series"
+   (seq-uniq
+    ;; Sorting *before* making unique because I want to favour upper-case
+    ;; over lower-case in the resulting list of series.
+    (sort (append (blogmore--post-series) (list series)) #'string-lessp)
+    #'string-equal-ignore-case))
+  (message "Added series '%s'" series))
+
+;;;###autoload
+(defun blogmore-remove-series (series)
+  "Remove SERIES from the post's series."
+  (interactive
+   (list (when-let (series (blogmore--post-series))
+           (completing-read "Series to remove: " series nil t))))
+  (when series
+    (blogmore-set-frontmatter "series" (remove series (blogmore--post-series)))
+    (message "Removed series '%s'" series)))
+
 (defun blogmore--post-tags ()
   "Get the tags for the current post as a list."
   (when-let ((tags (blogmore-get-frontmatter "tags")))
     (if (stringp tags)
         (string-split tags "," t " ")
       tags)))
-
-;;;###autoload
-(defun blogmore-set-series (series)
-  "Set the series of the post to SERIES."
-  (interactive (blogmore--with "Series" (blogmore--current-series)))
-  (blogmore-set-frontmatter "series" series))
 
 ;;;###autoload
 (defun blogmore-add-tag (tag)
@@ -800,7 +824,8 @@ If an image is found the return value is a list of the form:
     ("d" "Toggle draft status" blogmore-toggle-draft :inapt-if-not blogmore--blog-post-p)
     ("c" "Set post category" blogmore-set-category :inapt-if-not blogmore--blog-post-p)
     ("t" "Add tag" blogmore-add-tag :inapt-if-not blogmore--blog-post-p)
-    ("s" "Set series" blogmore-set-series :inapt-if-not blogmore--blog-post-p)
+    ("s" "Add series" blogmore-add-series :inapt-if-not blogmore--blog-post-p)
+    ("S" "Remove series" blogmore-remove-series :inapt-if-not blogmore--blog-post-p)
     ("T" "Remove tag" blogmore-remove-tag :inapt-if-not blogmore--blog-post-p)
     ("u d" "Update date" blogmore-update-date :inapt-if-not blogmore--blog-post-p)
     ("u m" "Update modified date" blogmore-update-modified :inapt-if-not blogmore--blog-post-p)]

--- a/blogmore.el
+++ b/blogmore.el
@@ -295,6 +295,17 @@ returns t."
   :type `(repeat (object :class blogmore-blog :value ,(blogmore-blog)))
   :group 'blogmore)
 
+(defcustom blogmore-command "blogmore"
+  "The command to run BlogMore operations that require the command-line tool.
+
+If BlogMore is installed and in your path the default setting should be
+fine. However, if you have multiple versions of BlogMore installed, or
+possibly have virtual environments appearing on your `exec-path', this
+might cause problems. If so you can set this to point to a specific
+instance of BlogMore."
+  :type '(file :must-match t)
+  :group 'blogmore)
+
 (defcustom blogmore-new-post-hook nil
   "Hook run after creating a new blog post."
   :type 'hook
@@ -460,61 +471,32 @@ to select a blog to work on first."
    (file-name-as-directory (blogmore--post-directory))
    (funcall (blogmore--post-file-name-from-title-function) title)))
 
-(defun blogmore--property-getter (property &optional separator)
-  "Generate a function to match PROPERTY in a string and return its value.
-
-If SEPARATOR is provided, split the values using SEPARATOR, returning a
-list of lists of values."
-  (lambda (candidate)
-    (when (string-match
-           (rx
-            bol (literal property) ":"
-            (zero-or-more space)
-            (group (zero-or-more any))
-            eol)
-           candidate)
-      (let ((value (string-trim (match-string 1 candidate))))
-        (if separator
-            (split-string value separator t " ")
-          value)))))
-
-(defun blogmore--get-all (property &optional separator)
-  "Get a list of all values for PROPERTY from existing posts.
-
-If SEPARATOR is provided, split the values using SEPARATOR and flatten
-the resulting list, returning a list of all values."
-  (seq-remove
-   #'string-empty-p
-   (funcall
-    (if separator #'flatten-list #'identity)
-    (mapcar
-     (blogmore--property-getter property separator)
-     (seq-uniq
-      (split-string
-       (shell-command-to-string
-        (format
-         (if (executable-find "rg")
-             "rg --no-filename --no-line-number --no-heading \"^%1$s:\" \"%2$s\" -g \"*.md\""
-           "find \"%2$s\" -type f -name \"*.md\" -exec grep -hi \"^%1$s:\" /dev/null {} +")
-         property (expand-file-name (blogmore--posts-directory))))
-       "\n" t)
-      #'string-equal-ignore-case)))))
+(defun blogmore--list-of (property)
+  "Get the PROPERTY list from BlogMore."
+  (if (executable-find blogmore-command)
+      (mapcar
+       #'cadr
+       (json-parse-string
+        (shell-command-to-string
+         (format "%s dump %s \"%s\" 2> %s"
+                 blogmore-command
+                 property
+                 (expand-file-name (blogmore--posts-directory))
+                 (shell-quote-argument (null-device))))
+        :array-type 'list))
+    (user-error "The 'blogmore' command-line tool is required for this operation; https://blogmore.davep.dev/")))
 
 (defun blogmore--current-categories ()
   "Get a list of categories from existing posts."
-  (sort (delq nil (blogmore--get-all "category")) #'string-lessp))
+  (blogmore--list-of "categories"))
 
 (defun blogmore--current-tags ()
   "Get a list of tags from existing posts."
-  (seq-uniq
-   ;; Sorting *before* making unique because I want to favour upper-case
-   ;; over lower-case in the resulting set.
-   (sort (blogmore--get-all "tags" ",") #'string-lessp)
-   #'string-equal-ignore-case))
+  (blogmore--list-of "tags"))
 
 (defun blogmore--current-series ()
   "Get a list of series from existing posts."
-  (sort (delq nil (blogmore--get-all "series")) #'string-lessp))
+  (blogmore--list-of "series"))
 
 (defun blogmore--post-picker ()
   "Pick a post from the list of existing posts."

--- a/blogmore.el
+++ b/blogmore.el
@@ -807,7 +807,9 @@ If an image is found the return value is a list of the form:
      (when-let ((category (blogmore-get-frontmatter "category" frontmatter)))
        (blogmore-set-category category))
      (when-let ((tags (blogmore-get-frontmatter "tags" frontmatter)))
-       (blogmore-set-frontmatter "tags" tags)))))
+       (blogmore-set-frontmatter "tags" tags))
+     (when-let ((series (blogmore-get-frontmatter "series" frontmatter)))
+       (blogmore-set-frontmatter "series" series)))))
 
 ;;;###autoload
 (transient-define-prefix blogmore ()

--- a/blogmore.el
+++ b/blogmore.el
@@ -664,7 +664,9 @@ If an image is found the return value is a list of the form:
 (defun blogmore--post-tags ()
   "Get the tags for the current post as a list."
   (when-let ((tags (blogmore-get-frontmatter "tags")))
-    (string-split tags "," t " ")))
+    (if (stringp tags)
+        (string-split tags "," t " ")
+      tags)))
 
 ;;;###autoload
 (defun blogmore-set-series (series)
@@ -678,13 +680,11 @@ If an image is found the return value is a list of the form:
   (interactive (blogmore--with "Tag" (blogmore--current-tags)))
   (blogmore-set-frontmatter
    "tags"
-   (string-join
-    (seq-uniq
-     ;; Sorting *before* making unique because I want to favour upper-case
-     ;; over lower-case in the resulting list of tags.
-     (sort (append (blogmore--post-tags) (list tag)) #'string-lessp)
-     #'string-equal-ignore-case)
-    ", "))
+   (seq-uniq
+    ;; Sorting *before* making unique because I want to favour upper-case
+    ;; over lower-case in the resulting list of tags.
+    (sort (append (blogmore--post-tags) (list tag)) #'string-lessp)
+    #'string-equal-ignore-case))
   (message "Added tag '%s'" tag)
   (when transient-current-prefix
     (call-interactively #'blogmore-add-tag)))
@@ -696,7 +696,7 @@ If an image is found the return value is a list of the form:
    (list (when-let (tags (blogmore--post-tags))
            (completing-read "Tag to remove: " tags nil t))))
   (when tag
-    (blogmore-set-frontmatter "tags" (string-join (remove tag (blogmore--post-tags)) ", "))
+    (blogmore-set-frontmatter "tags" (remove tag (blogmore--post-tags)))
     (message "Removed tag '%s'" tag)
     (when transient-current-prefix
       (call-interactively #'blogmore-remove-tag))))

--- a/blogmore.el
+++ b/blogmore.el
@@ -839,9 +839,9 @@ If an image is found the return value is a list of the form:
     ("d" "Toggle draft status" blogmore-toggle-draft :inapt-if-not blogmore--blog-post-p)
     ("c" "Set post category" blogmore-set-category :inapt-if-not blogmore--blog-post-p)
     ("t" "Add tag" blogmore-add-tag :inapt-if-not blogmore--blog-post-p)
+    ("T" "Remove tag" blogmore-remove-tag :inapt-if-not (lambda () (and (blogmore--blog-post-p) (blogmore--post-tags))))
     ("s" "Add series" blogmore-add-series :inapt-if-not blogmore--blog-post-p)
-    ("S" "Remove series" blogmore-remove-series :inapt-if-not blogmore--blog-post-p)
-    ("T" "Remove tag" blogmore-remove-tag :inapt-if-not blogmore--blog-post-p)
+    ("S" "Remove series" blogmore-remove-series :inapt-if-not (lambda () (and (blogmore--blog-post-p) (blogmore--post-series))))
     ("u d" "Update date" blogmore-update-date :inapt-if-not blogmore--blog-post-p)
     ("u m" "Update modified date" blogmore-update-modified :inapt-if-not blogmore--blog-post-p)]
    ["Links"

--- a/blogmore.el
+++ b/blogmore.el
@@ -472,10 +472,10 @@ to select a blog to work on first."
   (unless (executable-find blogmore-command)
     (user-error
      "The 'blogmore' command-line tool is required for this operation; https://blogmore.davep.dev/"))
-  (let* ((command (format "%s dump %s \"%s\" 2> %s"
-                          blogmore-command
-                          property
-                          (expand-file-name (blogmore--posts-directory))
+  (let* ((command (format "%s dump %s %s 2> %s"
+                          (shell-quote-argument (expand-file-name blogmore-command))
+                          (shell-quote-argument property)
+                          (shell-quote-argument (expand-file-name (blogmore--posts-directory)))
                           (shell-quote-argument (null-device))))
          (data (shell-command-to-string command)))
     (when (string-empty-p data)

--- a/blogmore.el
+++ b/blogmore.el
@@ -845,9 +845,7 @@ If an image is found the return value is a list of the form:
     ("t" "Add tag" blogmore-add-tag :inapt-if-not blogmore--blog-post-p)
     ("T" "Remove tag" blogmore-remove-tag :inapt-if-not (lambda () (and (blogmore--blog-post-p) (blogmore--post-tags))))
     ("s" "Add series" blogmore-add-series :inapt-if-not blogmore--blog-post-p)
-    ("S" "Remove series" blogmore-remove-series :inapt-if-not (lambda () (and (blogmore--blog-post-p) (blogmore--post-series))))
-    ("u d" "Update date" blogmore-update-date :inapt-if-not blogmore--blog-post-p)
-    ("u m" "Update modified date" blogmore-update-modified :inapt-if-not blogmore--blog-post-p)]
+    ("S" "Remove series" blogmore-remove-series :inapt-if-not (lambda () (and (blogmore--blog-post-p) (blogmore--post-series))))]
    ["Links"
     ("l c" "Link to a category" blogmore-link-category :inapt-if-not blogmore--blog-post-p)
     ("l p" "Link to a post" blogmore-link-post :inapt-if-not blogmore--blog-post-p)
@@ -858,6 +856,8 @@ If an image is found the return value is a list of the form:
     ("i c" "Toggle image centre at point" blogmore-toggle-image-centre :inapt-if-not blogmore--image-at-point)
     ("i s" "Set image at point as cover" blogmore-set-as-cover :inapt-if-not blogmore--image-at-point)]
    ["Other"
+    ("u d" "Update date" blogmore-update-date :inapt-if-not blogmore--blog-post-p)
+    ("u m" "Update modified date" blogmore-update-modified :inapt-if-not blogmore--blog-post-p)
     ("C t" "Toggle invite comments" blogmore-toggle-invite-comments :inapt-if-not blogmore--blog-post-p)
     ("C a" "Comments to address" blogmore-invite-comments-to :inapt-if-not blogmore--blog-post-p)
     ("o s" "Toggle show ToC" blogmore-toggle-show-toc :inapt-if-not blogmore--blog-post-p)

--- a/dev-environment.el
+++ b/dev-environment.el
@@ -4,13 +4,12 @@
 
 (setq package-user-dir (expand-file-name ".packages" default-directory)
       package-archives
-      '(("gnu"   . "https://elpa.gnu.org/packages/")
-        ("melpa" . "https://melpa.org/packages/")))
+      '(("gnu" . "https://elpa.gnu.org/packages/")))
 
 (package-initialize)
 
 (unless package-archive-contents
-  (message "Refreshing package archives from ELPA/MELPA...")
+  (message "Refreshing package archives from ELPA...")
   (package-refresh-contents))
 
 (defvar project-dependencies '(yaml)

--- a/dev-environment.el
+++ b/dev-environment.el
@@ -1,0 +1,26 @@
+;; Isolated development environment.
+
+(require 'package)
+
+(setq package-user-dir (expand-file-name ".packages" default-directory)
+      package-archives
+      '(("gnu"   . "https://elpa.gnu.org/packages/")
+        ("melpa" . "https://melpa.org/packages/")))
+
+(package-initialize)
+
+(unless package-archive-contents
+  (message "Refreshing package archives from ELPA/MELPA...")
+  (package-refresh-contents))
+
+(defvar project-dependencies '(yaml)
+  "List of packages required to build and test the project.")
+
+(dolist (pkg project-dependencies)
+  (unless (package-installed-p pkg)
+    (message "Installing dependency: %s" pkg)
+    (package-install pkg)))
+
+(package-activate-all)
+
+;;; dev-environment.el ends here


### PR DESCRIPTION
This PR greatly improves the handling of frontmatter in posts. The main changes include:

- Switched to using `yaml.el` to handle the parsing of the content of frontmatter in the buffer; moving away from the previous mostly-good-enough regex-based parsing.
- Dropped the use of `rg`/`grep` to find pre-existing categories, tags and series, instead moving to using the work done in https://github.com/davep/blogmore/pull/612 that provides direct dumps of such information from a blog.

This means that a number of things have changed:

- When editing frontmatter values, most strings will get quoted
- When editing frontmatter values, lists will always get surrounded by `[` and `]`
- The first time a category, tag or series is set there will be a pause as `blogmore` is called to get the relevant list; this is cached until you change blog or call `blogmore-clear-cache`